### PR TITLE
Edits on several documentation pages.

### DIFF
--- a/How-to-Setup.md
+++ b/How-to-Setup.md
@@ -2,41 +2,54 @@
 title: "How to Setup"
 has_children: true
 ---
-# How to Setup
+# How to Set Up ArchWSL
 
 ## Requirements
+
 * Windows 10 1709 Fall Creators Update 64bit or later.
 * Windows Subsystem for Linux feature is enabled.
 
-## Install
-### with zip package
-#### 1. [Download](https://github.com/yuk7/ArchWSL/releases/latest) installer zip
+## Installation Instructions
 
-#### 2. Extract all files in zip file to same directory
-Please extract to a folder that has write permission.
-For example 'Program Files' can not be used.
+There are two ways to install ArchWSL.
 
-#### 3. Run Arch.exe to Extract rootfs and Register to WSL
-Exe filename is using to the instance name to register.
-If you rename it you can register with a different name and have multiple installs.
+### Method 1: zip file
 
-### with appx package
-#### 1. [Download](https://github.com/yuk7/ArchWSL/releases/latest) installer .appx and .cer
-#### 2. Install .cer to "Trusted Root Certificate Store" of the local machine
-[For details, please refer to Install Certificate page.](Install-Certificate.md)
+1. [Download](https://github.com/yuk7/ArchWSL/releases/latest) installer zip
+2. Extract all files in zip file to the same directory.
+   Please extract to a folder that has write permission.
+   For example, `C:\Program Files` cannot be used.
+3. Run `Arch.exe` to extract the rootfs and register to WSL
 
-You need administrator privileges to install the certificate
-#### 3. Install .appx
+As a side note, the executable name is what is used as the WSL instance name.
+If you rename it, you can have multiple installs.
+See [@yuk7/wsldl/main.c](https://github.com/yuk7/wsldl/blob/00b0a696128d07192565ccf7e337e0797f9ee999/main.c#L57-L96).
 
-## Setting for Arch
-#### 1.Setting root password
-```
+### Method 2: appx pacakge
+
+1. [Download the `.appx` and `.cer`](https://github.com/yuk7/ArchWSL/releases/latest)
+2. Install `.cer` to the "Trusted Root Certificate Store" of the local machine.
+   For details, please refer to the [Install Certificate page](Install-Certificate.md).
+   You will need administrator privileges to install the certificate.
+3. Install the `.appx`
+
+## Settings for Arch installing ArchWSL
+
+### Setting the root password
+
+```shell
 >Arch.exe
 [root@PC-NAME user]# passwd
 ```
 
-#### 2.Setup default user  (Please see ArchWiki [Sudo](https://wiki.archlinux.org/index.php/Sudo#Example_entries) and [User and groups](https://wiki.archlinux.org/index.php/Users_and_groups) pages.)
-```
+### Set up the default user
+
+Please see ArchWiki
+[Sudo](https://wiki.archlinux.org/index.php/Sudo#Example_entries)
+and
+[User and groups](https://wiki.archlinux.org/index.php/Users_and_groups) pages.
+
+```shell
 >Arch.exe
 [root@PC-NAME]# EDITOR=nano visudo
     %wheel      ALL=(ALL) ALL
@@ -52,12 +65,24 @@ You need administrator privileges to install the certificate
 
 >Arch.exe config --default-user {username}
     (setting to default user)
-````
-If the default user has not been changed(issue [#7](https://github.com/yuk7/ArchWSL/issues/7)), please reboot the computer or alternatively, restart the LxssManager in an Admin command prompt
-`net stop lxssmanager && net start lxssmanager`
+```
 
-#### 3.Initialize keyring
-Please excute these commands for initialize keyring.(This step is necessary for use pacman)
+If the default user has not been changed
+([issue #7](https://github.com/yuk7/ArchWSL/issues/7)),
+please reboot the computer or alternatively, restart the LxssManager in an Admin
+command prompt.
+
+To restart the `LxssManager`, run this:
+
+```batch
+net stop lxssmanager && net start lxssmanager
+```
+
+### Initialize keyring
+
+Please excute these commands to initialize the keyring.
+(This step is necessary to use pacman.)
+
 ```shell
 >Arch.exe
 [user@PC-NAME]$ sudo pacman-key --init
@@ -65,8 +90,7 @@ Please excute these commands for initialize keyring.(This step is necessary for 
 [root@PC-NAME]$ sudo pacman-key --populate
 ```
 
-#### Optional. Install systemctl alternative
-We can't use systemd on WSL,this is WSL specification.
-However,There are several solutions.
+### Install systemctl alternative (Optional)
 
+WSL does not have support for systemd however, there are several solutions.
 Please see [Known issues](Known-issues.md#systemdsystemctl).

--- a/How-to-Use.md
+++ b/How-to-Use.md
@@ -1,7 +1,8 @@
 ---
 title: "How to Use"
 ---
-# How to Use (Installed Instance)
+# How to Use (after ArchWSL is installed)
+
 ## exe Usage
 
 ```
@@ -39,52 +40,63 @@ Usage :
 ```
 
 
-## Just Run exe
+## Open an interactive shell
+
 ```
 >Arch.exe
 [root@PC-NAME user]#
 ```
 
-## Run with command line
+## Run a single command and exit
+
 ```
 >Arch.exe run uname -r
 4.4.0-43-Microsoft
 ```
 
-## Run with command line with path translation
+## Run a command with path translation and exit
+
 ```
 >Arch.exe runp echo C:\Windows\System32\cmd.exe
 /mnt/c/Windows/System32/cmd.exe
 ```
 
-## Change Default User(id command required)
+## Change Default User (id command required)
+
 ```
 >Arch.exe config --default-user user
 
 >Arch.exe
 [user@PC-NAME dir]$
 ```
-If the default user has not been changed, please reboot the computer.(issue [#7](https://github.com/yuk7/ArchWSL/issues/7))
-> You can try to do before it (From [This Comment](https://github.com/yuk7/ArchWSL/issues/7#issuecomment-397725710))
->```
->sc stop LxssManager
->sc start LxssManager
->```
 
-## How to backup instance image
-backup
+If the default user has not been changed
+([issue #7](https://github.com/yuk7/ArchWSL/issues/7)),
+please reboot the computer or alternatively, restart the LxssManager in an Admin
+command prompt.
+
+To restart the `LxssManager`, run this:
+
+```batch
+net stop lxssmanager && net start lxssmanager
+```
+
+## Backup Rootfs
+
+Backup:
+
 ```
 >Arch.exe backup
 ```
-restore/install backup tarball
+
+Restore/install backup tarball:
+
 ```
 >Arch.exe install full/path/to/backup.tar.gz
 ```
 
-
-## How to uninstall instance
+## Uninstall Instance
 
 ```
 >Arch.exe clean
-
 ```

--- a/Install-Certificate.md
+++ b/Install-Certificate.md
@@ -5,26 +5,28 @@ parent: "How to Setup"
 ---
 
 # Install Certificate for AppX
-ArchWSL is a program not approved by Microsoft.
 
-To use the ArchWSL of appx version, you will need to install a code signing certificate manually.
+ArchWSL is not approved by Microsoft. Therefore, you will need to install a code
+signing certificate manually if you want to install using the `.appx` package.
+The certificate must be installed in the "Trusted Root Certificate Store" of the
+local machine.
 
-The certificate must be installed in the "Trusted Root Certificate Store" of the local machine.
+## Instructions
 
-## Instruction
-
-### 1. Open the .cer file and click "Install Certificate".
+1. Open the .cer file and click "Install Certificate".
 
 ![screenshot1](img/cert/1.install.png)
 
-### 2. Select "Local Machine" and Next.
+2. Select "Local Machine" and Next.
 
 ![screenshot2](img/cert/2.to-localmachine.png)
 
-### 3. Select "Place ~ in the following store" and Click Browse to select installation destination.
+3. Select "Place ~ in the following store" and Click Browse to select installation destination.
+
 ![screenshot3](img/cert/3.to-following.png)
 
-### 4. Select "Trusted Root Certification Authorities" and OK.
+4. Select "Trusted Root Certification Authorities" and OK.
+
 ![screenshot4](img/cert/4.to-rootstore.png)
 
-### 5. done
+5. done


### PR DESCRIPTION
Mostly on How-to-Setup.
Maybe think about renaming to "installation-instructions"?