### PR TITLE
Use sudoers.d/wheel file instead of editing sudoers

### DIFF
--- a/How-to-Setup.md
+++ b/How-to-Setup.md
@@ -50,9 +50,8 @@ and
 
 ```shell
 >Arch.exe
-[root@PC-NAME]# EDITOR=nano visudo
-    %wheel      ALL=(ALL) ALL
-    (setup sudoers file.)
+[root@PC-NAME]# echo "%wheel ALL=(ALL) ALL" > /etc/sudoers.d/wheel
+(setup sudoers file.)
 
 [root@PC-NAME]# useradd -m -G wheel -s /bin/bash {username}
 (add user)


### PR DESCRIPTION
I find it more convenient to use conf.d files instead of changing config files directly. Adding `wheel` to sudoers can be done using such file.