### PR TITLE
Change Translates to Translations

### DIFF
--- a/locale/translates.md
+++ b/locale/translates.md
@@ -1,9 +1,9 @@
 ---
-title: "Translates"
+title: "Translations"
 has_children: true
 ---
 
-# Translatesyuk7/ArchW-docs
+# Translations
 
 [English](../README.md)
 


### PR DESCRIPTION
I also removed the extra text "yuk7/ArchW-docs". I don't know if it is supposed to be there so I made a new branch and opened a pull request so that it won't directly affect the website.

I think "Translations" sounds much better grammatically speaking.