### PR TITLE
Update Known-issues.md

### DIFF
--- a/Known-issues.md
+++ b/Known-issues.md
@@ -67,9 +67,9 @@ However, this is only partially compatible.
 Download [systemd-altctl-1.4.4181-1-any.pkg.tar.xz](https://github.com/yuk7/arch-systemctl-alt/releases/download/1.4.4181-1/systemd-altctl-1.4.4181-1-any.pkg.tar.xz) and run ```pacman -U systemd-altctl-1.4.4181-1-any.pkg.tar.xz``` to install.
 
 ### WSL2
-You can use systemd bottle "[subsystemctl](https://github.com/sorah/subsystemctl)" or "[genie](https://github.com/arkane-systems/genie)".
+You can use systemd bottle "[subsystemctl](https://github.com/sorah/subsystemctl)", "[genie](https://github.com/arkane-systems/genie)" or "[wsl-distrod](https://github.com/nullpo-head/wsl-distrod)".
 
-Using it, you can run systemd completely.
+Using any of the aformentioned solutions, will allow you to run systemd completely.
 
 #### subsystemctl
 You can download [PKGBUILD](https://raw.githubusercontent.com/sorah/arch.sorah.jp/master/aur-sorah/PKGBUILDs/subsystemctl/PKGBUILD) and build it.


### PR DESCRIPTION
Add a new systemd alternative for WSL2.

I've tested this personally and it's working like a charm. Compared to genie which has some quirks, this one seems to be rock solid and very easy to install on top of ArchWSL. I've followed these instructions and it integrated quite immediately: https://github.com/nullpo-head/wsl-distrod#option-2-make-your-current-distro-run-systemd