### PR TITLE
Update Known-issues.md

### DIFF
--- a/Known-issues.md
+++ b/Known-issues.md
@@ -67,7 +67,7 @@ However, this is only partially compatible.
 Download [systemd-altctl-1.4.4181-1-any.pkg.tar.xz](https://github.com/yuk7/arch-systemctl-alt/releases/download/1.4.4181-1/systemd-altctl-1.4.4181-1-any.pkg.tar.xz) and run ```pacman -U systemd-altctl-1.4.4181-1-any.pkg.tar.xz``` to install.
 
 ### WSL2
-You can use systemd bottle "[subsystemctl](https://github.com/sorah/subsystemctl)", "[genie](https://github.com/arkane-systems/genie)" or "[wsl-distrod](https://github.com/nullpo-head/wsl-distrod)".
+You can use systemd bottle "[subsystemctl](https://github.com/sorah/subsystemctl)", "[genie](https://github.com/arkane-systems/genie)", "[wsl-distrod](https://github.com/nullpo-head/wsl-distrod)" or "[bottled-shell](https://github.com/lungothrin/bottled-shell)".
 
 Using any of the aformentioned solutions, will allow you to run systemd completely.
 


### PR DESCRIPTION
Add a new systemd alternative for WSL2.

I've tested it personally. Compared to other solutions, this solution finally support launch systemd-enabled shell directly from start menu, and VSCode Remote - WSL extension. Maybe someone interested in trying it out.

https://github.com/lungothrin/bottled-shell