### PR TITLE
pt-BR: Rename main title

### DIFF
--- a/locale/pt-BR/How-to-Setup.md
+++ b/locale/pt-BR/How-to-Setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Como configurar"
-parent: "Início"
+parent: "Português Brasileiro"
 grand_parent: "Translations"
 has_children: true
 ---

--- a/locale/pt-BR/How-to-Use.md
+++ b/locale/pt-BR/How-to-Use.md
@@ -1,6 +1,6 @@
 ---
 title: "Como usar"
-parent: "Início"
+parent: "Português Brasileiro"
 grand_parent: "Translations"
 ---
 # Como usar (após a instalação do ArchWSL)

--- a/locale/pt-BR/Known-issues.md
+++ b/locale/pt-BR/Known-issues.md
@@ -1,6 +1,6 @@
 ---
 title: "Problemas conhecidos"
-parent: "Início"
+parent: "Português Brasileiro"
 grand_parent: "Translations"
 ---
 # Problemas conhecidos

--- a/locale/pt-BR/README.md
+++ b/locale/pt-BR/README.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Início"
+title: "Português Brasileiro"
 parent: "Translations"
 description: "O início do mundo"
 permalink: /locale/pt-BR/


### PR DESCRIPTION
Previously I used Home translation, but using the translated language name seems more proper since that is what was done in other languages.