### PR TITLE
Fix command to enable archlinuxcn

### DIFF
--- a/Known-issues.md
+++ b/Known-issues.md
@@ -15,8 +15,8 @@ You can use `glibc-linux4`[ᴬᵁᴿ](https://aur.archlinux.org/packages/glibc-l
 
 You can install from archlinuxcn community repository (can auto-update, recommend)
 ```
-echo "[archlinuxcn]
-Server = https://repo.archlinuxcn.org/$arch" >> /etc/pacman.conf
+echo '[archlinuxcn]
+Server = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
 sudo pacman -Syy && sudo pacman -S archlinuxcn-keyring && sudo pacman -S glibc-linux4
 ```
 or you can install from AUR helper

--- a/locale/pt-BR/Known-issues.md
+++ b/locale/pt-BR/Known-issues.md
@@ -17,8 +17,8 @@ Você pode usar o pacote `glibc-linux4`[ᴬᵁᴿ](https://aur.archlinux.org/pac
 
 Você pode instalar a partir do repositório da comunidade archlinuxcn (pode atualizar automaticamente, recomendado)
 ```
-echo "[archlinuxcn]
-Server = https://repo.archlinuxcn.org/$arch" >> /etc/pacman.conf
+echo '[archlinuxcn]
+Server = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
 sudo pacman -Syy && sudo pacman -S archlinuxcn-keyring && sudo pacman -S glibc-linux4
 ```
 ou você pode instalar a partir com um auxiliar do AUR ("AUR helper")

--- a/locale/zh-CN/Known-issues.md
+++ b/locale/zh-CN/Known-issues.md
@@ -18,8 +18,8 @@ Arch 默认的 Glibc 包是为新版本 Linux 内核的 syscall 设计的，而 
 
 建议从 archlinuxcn 社区仓库安装此包，以方便自动更新。
 ```
-echo "[archlinuxcn]
-Server = https://repo.archlinuxcn.org/$arch" >> /etc/pacman.conf
+echo '[archlinuxcn]
+Server = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
 sudo pacman -Syy && sudo pacman -S archlinuxcn-keyring && sudo pacman -S glibc-linux4
 ```
 当然，你也可以直接使用 AUR 助手安装。


### PR DESCRIPTION
Using double quotes caused $arch to be read as a shell variable and not be added to /etc/pacman.conf.  Using single quotes avoids this issue.

See #33