### PR TITLE
Solve `GLIBC_2.34 not found`

### DIFF
--- a/How-to-Setup.md
+++ b/How-to-Setup.md
@@ -88,7 +88,9 @@ Please excute these commands to initialize the keyring.
 
 [user@PC-NAME]$ sudo pacman-key --populate
 
-[user@PC-NAME]$ sudo pacman -Syy archlinux-keyring
+[user@PC-NAME]$ sudo pacman -Syu
+
+[user@PC-NAME]$ sudo pacman -S archlinux-keyring
 ```
 
 ### Install patched glibc (need in WSL1)


### PR DESCRIPTION
Hi, 
this PR solves the issue https://github.com/yuk7/ArchWSL/issues/280

As stated here https://bbs.archlinux.org/viewtopic.php?id=274705, executing `sudo pacman -Syy ...` before upgrading the whole system could lead to partial upgrades.

Thanks