### PR TITLE
Install arch keyring before attempting upgrades

### DIFF
--- a/How-to-Setup.md
+++ b/How-to-Setup.md
@@ -97,9 +97,9 @@ Please excute these commands to initialize the keyring.
 
 [user@PC-NAME]$ sudo pacman-key --populate
 
-[user@PC-NAME]$ sudo pacman -Syu
-
 [user@PC-NAME]$ sudo pacman -S archlinux-keyring
+
+[user@PC-NAME]$ sudo pacman -Syu
 ```
 
 ### Install patched glibc (need in WSL1)

--- a/How-to-Setup.md
+++ b/How-to-Setup.md
@@ -97,9 +97,9 @@ Please excute these commands to initialize the keyring.
 
 [user@PC-NAME]$ sudo pacman-key --populate
 
-[user@PC-NAME]$ sudo pacman -S archlinux-keyring
+[user@PC-NAME]$ sudo pacman -Sy archlinux-keyring
 
-[user@PC-NAME]$ sudo pacman -Syu
+[user@PC-NAME]$ sudo pacman -Su
 ```
 
 ### Install patched glibc (need in WSL1)


### PR DESCRIPTION
Need keys to be known first otherwise:
```
error: <package>: key "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" is unknown
...
File /var/cache/pacman/pkg/<package>.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
``` 