### PR TITLE
Add information about native systemd support

### DIFF
--- a/Known-issues.md
+++ b/Known-issues.md
@@ -58,7 +58,14 @@ sudo dbus-daemon --system
 ```
 
 ## systemd/systemctl
-WSL does not supports systemd natively, so we recommend using a systemctl alternative script or bottle for apps that require it.
+
+If you're using WSL 0.67.6 and above (see `wsl --version`), systemd is natively supported. To enable it, edit `/etc/wsl.conf` and then restart the distro.
+```
+[boot]
+systemd=true
+```
+
+If you're using an older version of WSL, we recommend using a systemctl alternative script or bottle for apps that require it.
 
 ### WSL1 / WSL2
 You can use a systemctl alternative script.


### PR DESCRIPTION
[WSL >=0.67.6 natively supports systemd](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)

However, I'm currently using Windows 11 Beta (22623.730), manually updated wsl with `wsl --update` to version 0.70.0 and it's working without me needing to add that flag in `/etc/wsl.conf`, so I'm not sure if I'm missing something. I added the info about adding the flag to be in sync with what Microsoft says officially 